### PR TITLE
Update Readme for loading Firefox extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,19 +3,29 @@
 ## Get started
 
 1. Install the dependencies
+
 ```bash
 yarn
 ```
 
 2. Run build script
+
 ```bash
 yarn build
 ```
 
 3. Load your extension on browser
+
    1. Chrome
+
       1. Goto `chrome://extensions/`
       2. Enable `Developer mode`
       3. Click on `Load unpacked`
       4. Select the `public` folder
-   2. Firefox [TODO]
+
+   2. Firefox
+
+      1. Open Firefox
+      2. Goto `about:debugging#addons`
+      3. Click on `Load Temporary Add-on`
+      4. Select the `public/manifest.json` file


### PR DESCRIPTION
# Description
Update Readme for loading Firefox extension.
We can also load the extension into Firefox browser.

# Screenshots
### Fig: Type `about:debugging#addons`
![image](https://user-images.githubusercontent.com/19724279/100450899-9116de00-30de-11eb-934c-8e460a4001e7.png)

### Fig: Load extension
![image](https://user-images.githubusercontent.com/19724279/100449942-d33f2000-30dc-11eb-8ee1-3d5a7fea9449.png)

### Fig: Loaded extension
![image](https://user-images.githubusercontent.com/19724279/100449986-efdb5800-30dc-11eb-8875-e3e9e6e2e42f.png)

### Fig: The Firefox extension window
![image](https://user-images.githubusercontent.com/19724279/100450336-9293d680-30dd-11eb-95fe-1a9e45e1c77e.png)

